### PR TITLE
Reduce load on Slurm databases by checking for running jobs locally.

### DIFF
--- a/files/gpu_stat.py
+++ b/files/gpu_stat.py
@@ -12,7 +12,8 @@ def jobs_running():
    """find slurm-job-ids active on this node
 
    Returns list of Slurm JobIDs.  JobIDs are strings."""
-   data = subprocess.check_output(['squeue', '-w', os.uname()[1].split('.')[0], '-h', '-o', '%A'])
+   #data = subprocess.check_output(['squeue', '-w', os.uname()[1].split('.')[0], '-h', '-o', '%A'])
+   data = subprocess.check_output(r"ps aux | grep [s]lurmstepd | sed --regexp-extended 's/.*\[([0-9]+)\..*/\1/' | sort | uniq", shell=True)
    data = data.decode()
    return data.split()
 

--- a/files/gpu_stat.py
+++ b/files/gpu_stat.py
@@ -11,6 +11,7 @@ import os
 def jobs_running():
    """find slurm-job-ids active on this node"""
    data = subprocess.check_output(['squeue', '-w', os.uname()[1].split('.')[0], '-h', '-o', '%A'])
+   data = data.decode()
    return data.split()
 
 
@@ -28,6 +29,7 @@ def pid2id(pid):
 def job_info(jobs,current):
    for job in jobs:
       output = subprocess.check_output(['scontrol', '-o', 'show', 'job', job])
+      output = output.decode()
       cpus   = re.search('NumCPUs=(\d+)', output)
       tres   = re.search('TRES=(\S+)', output).group(1)
       nodes  = re.search('NumNodes=(\d+)', output)
@@ -55,6 +57,7 @@ def gpu_info(jobinfo):
    import xml.etree.cElementTree as ET
 
    output = subprocess.check_output(['nvidia-smi', '-q', '-x'])
+   output = output.decode()
    root = ET.fromstring(output)
 
    for gpu in root.findall('gpu'):


### PR DESCRIPTION
- This parses the process list and slurmstepd to get the jobs running
  on the node.  It avoids squeue calls for every node every minute,
  but has more risk of errors when slurmstepd changes in the future.

- In the future this parsing step could possibly be entirely avoided
  by only using job IDs found from the Slurm cgroups - could one
  refactor it to work this way?